### PR TITLE
Show usages of NgtStore and NgtComponentStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "karma-coverage": "~2.1.0",
         "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "~1.7.0",
+        "prettier": "2.6.2",
         "typescript": "~4.5.2"
       }
     },
@@ -9293,6 +9294,21 @@
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
     },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -18318,6 +18334,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "karma-coverage": "~2.1.0",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "~1.7.0",
+    "prettier": "2.6.2",
     "typescript": "~4.5.2"
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,71 +1,164 @@
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { NgtCannonDebugModule, NgtPhysicsModule } from '@angular-three/cannon';
 
-import { NgtCanvasModule, NgtColorPipeModule, NgtRadianPipeModule, NgtVectorPipeModule } from '@angular-three/core';
-import { NgtStatsModule } from '@angular-three/core/stats';
-import { NgtInstancedMeshModule, NgtMeshModule } from '@angular-three/core/meshes';
+import {
+  NgtCanvasModule,
+  NgtColorPipeModule,
+  NgtRadianPipeModule,
+  NgtVectorPipeModule,
+} from '@angular-three/core';
+import {
+  NgtColorAttributeModule,
+  NgtInstancedBufferAttributeModule,
+} from '@angular-three/core/attributes';
+import {
+  NgtBoxGeometryModule,
+  NgtCylinderGeometryModule,
+  NgtPlaneGeometryModule,
+  NgtPolyhedronGeometryModule,
+  NgtSphereGeometryModule,
+  NgtTorusGeometryModule,
+} from '@angular-three/core/geometries';
 import { NgtGroupModule } from '@angular-three/core/group';
-import { NgtMeshLambertMaterialModule, NgtMeshStandardMaterialModule } from '@angular-three/core/materials';
-import { NgtBoxGeometryModule, NgtCylinderGeometryModule, NgtPlaneGeometryModule, NgtPolyhedronGeometryModule, NgtSphereGeometryModule, NgtTorusGeometryModule } from '@angular-three/core/geometries';
-import { NgtAmbientLightModule, NgtDirectionalLightModule, NgtPointLightModule, NgtSpotLightModule } from '@angular-three/core/lights';
-import { NgtArrowHelperModule, NgtBoxHelperModule } from '@angular-three/core/helpers';
-import { NgtInstancedBufferAttributeModule } from '@angular-three/core/attributes';
-
-import { NgtPhysicsModule } from '@angular-three/cannon';
+import {
+  NgtArrowHelperModule,
+  NgtBoxHelperModule,
+} from '@angular-three/core/helpers';
+import {
+  NgtAmbientLightModule,
+  NgtDirectionalLightModule,
+  NgtPointLightModule,
+  NgtSpotLightModule,
+} from '@angular-three/core/lights';
+import {
+  NgtMeshLambertMaterialModule,
+  NgtMeshStandardMaterialModule,
+} from '@angular-three/core/materials';
+import {
+  NgtInstancedMeshModule,
+  NgtMeshModule,
+} from '@angular-three/core/meshes';
+import { NgtStatsModule } from '@angular-three/core/stats';
 
 import { NgtSobaTextModule } from '@angular-three/soba/abstractions';
 import { NgtSobaOrbitControlsModule } from '@angular-three/soba/controls';
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppRoutingModule } from './app-routing.module';
 
 import { AppComponent } from './app.component';
+import { ConveyorVolumeComponent } from './components/conveyor-volume.component';
+import { FirstPersonControlsComponent } from './components/first-person-controls.component';
+import { FloorComponent } from './components/floor.component';
+import { RagdollModelComponent } from './components/ragdoll-model/ragdoll-model.component';
+import { RaycastVehicleModelComponent } from './components/raycast-vehicle-model/raycast-vehicle-model.component';
+import { RigidBodyModelComponent } from './components/rigidbody-model/rigidbody-model.component';
 import { CubeComponent } from './components/storybook-cube.component';
-import { NgtCannonDebugModule } from '@angular-three/cannon';
 import { TriggerCubeComponent } from './components/trigger-cube.component';
+import {
+  BodyTypesComponent,
+  BodyTypesExample,
+} from './examples/body_types/body_types.component';
+import {
+  BounceComponent,
+  BounceExample,
+} from './examples/bounce/bounce.component';
+import {
+  CallbacksComponent,
+  CallbacksExample,
+} from './examples/callbacks/callbacks.component';
+import { ClothComponent, ClothExample } from './examples/cloth/cloth.component';
+import {
+  CollisionFilterComponent,
+  CollisionFilterExample,
+} from './examples/collision_filter/collision_filter.component';
+import {
+  CollisionsComponent,
+  CollisionsExample,
+} from './examples/collisions/collisions.component';
+import {
+  CompoundComponent,
+  CompoundExample,
+} from './examples/compound/compound.component';
+import { ConditionalComponent } from './examples/conditional/conditional.component';
+import {
+  ConstraintsComponent,
+  ConstraintsExample,
+} from './examples/constraints/constraints.component';
+import {
+  ContainerComponent,
+  ContainerExample,
+} from './examples/container/container.component';
+import {
+  ConvexComponent,
+  ConvexExample,
+} from './examples/convex/convex.component';
+import { ConveyorComponent } from './examples/conveyor/conveyor.component';
+import {
+  EventsComponent,
+  EventsExample,
+} from './examples/events/events.component';
+import {
+  FixedRotationComponent,
+  FixedRotationExample,
+} from './examples/fixed_rotation/fixed_rotation.component';
+import { FPSComponent, FPSExample } from './examples/fps/fps.component';
+import {
+  FrictionComponent,
+  FrictionExample,
+} from './examples/friction/friction.component';
+import {
+  HeightfieldComponent,
+  HeightfieldExample,
+} from './examples/heightfield/heightfield.component';
+import { HingeComponent, HingeExample } from './examples/hinge/hinge.component';
+import {
+  ImpulseComponent,
+  ImpulseExample,
+} from './examples/impulse/impulse.component';
+import { JengaComponent, JengaExample } from './examples/jenga/jenga.component';
+import {
+  MousePickComponent,
+  MousePickExample,
+} from './examples/mousepick/mousepick.component';
+import {
+  PerformanceComponent,
+  PerformanceExample,
+} from './examples/performance/performance.component';
+import { PileComponent, PileExample } from './examples/pile/pile.component';
+import { RagdollComponent } from './examples/ragdoll/ragdoll.component';
+import { RaycastVehicleComponent } from './examples/raycast_vehicle/raycast_vehicle.component';
+import { RigidVehicleComponent } from './examples/rigid_vehicle/rigid_vehicle.component';
+import { SleepComponent, SleepExample } from './examples/sleep/sleep.component';
+import {
+  SpringComponent,
+  SpringExample,
+} from './examples/spring/spring.component';
+import {
+  StacksComponent,
+  StacksExample,
+} from './examples/stacks/stacks.component';
+import { TearComponent, TearExample } from './examples/tear/tear.component';
+import {
+  ThreeJSComponent,
+  ThreeJSExample,
+} from './examples/threejs/threejs.component';
+import {
+  TriggerComponent,
+  TriggerExample,
+} from './examples/trigger/trigger.component';
+import {
+  TrimeshComponent,
+  TrimeshExample,
+} from './examples/trimesh/trimesh.component';
+import { TweenComponent, TweenExample } from './examples/tween/tween.component';
+import { VRComponent, VRExample } from './examples/vr/vr.component';
+import {
+  WorkerComponent,
+  WorkerExample,
+} from './examples/worker/worker.component';
+import { HomeComponent } from './home.component';
 import { XRBatComponent } from './xr-bat/xr-bat.component';
 import { XRInspectComponent } from './xr-inspect/xr-inspect.component';
-import { AppRoutingModule } from './app-routing.module';
-import { VRComponent, VRExample } from './examples/vr/vr.component';
-import { HomeComponent } from './home.component';
-import { ThreeJSComponent, ThreeJSExample } from './examples/threejs/threejs.component';
-import { WorkerComponent, WorkerExample } from './examples/worker/worker.component';
-import { BounceComponent, BounceExample } from './examples/bounce/bounce.component';
-import { CollisionFilterComponent, CollisionFilterExample } from './examples/collision_filter/collision_filter.component';
-import { CollisionsComponent, CollisionsExample } from './examples/collisions/collisions.component';
-import { CompoundComponent, CompoundExample } from './examples/compound/compound.component';
-import { ContainerComponent, ContainerExample } from './examples/container/container.component';
-import { EventsComponent, EventsExample } from './examples/events/events.component';
-import { FixedRotationComponent, FixedRotationExample } from './examples/fixed_rotation/fixed_rotation.component';
-import { FrictionComponent, FrictionExample } from './examples/friction/friction.component';
-import { ImpulseComponent, ImpulseExample } from './examples/impulse/impulse.component';
-import { JengaComponent, JengaExample } from './examples/jenga/jenga.component';
-import { TriggerComponent, TriggerExample } from './examples/trigger/trigger.component';
-import { TrimeshComponent, TrimeshExample } from './examples/trimesh/trimesh.component';
-import { SleepComponent, SleepExample } from './examples/sleep/sleep.component';
-import { TweenComponent, TweenExample } from './examples/tween/tween.component';
-import { ConvexComponent, ConvexExample } from './examples/convex/convex.component';
-import { BodyTypesComponent, BodyTypesExample } from './examples/body_types/body_types.component';
-import { PerformanceComponent, PerformanceExample } from './examples/performance/performance.component';
-import { PileComponent, PileExample } from './examples/pile/pile.component';
-import { StacksComponent, StacksExample } from './examples/stacks/stacks.component';
-import { ClothComponent, ClothExample } from './examples/cloth/cloth.component';
-import { FPSComponent, FPSExample } from './examples/fps/fps.component';
-import { FirstPersonControlsComponent } from './components/first-person-controls.component';
-import { ConveyorComponent } from './examples/conveyor/conveyor.component';
-import { ConveyorVolumeComponent } from './components/conveyor-volume.component';
-import { ConditionalComponent } from './examples/conditional/conditional.component';
-import { MousePickComponent, MousePickExample } from './examples/mousepick/mousepick.component';
-import { CallbacksComponent, CallbacksExample } from './examples/callbacks/callbacks.component';
-import { HeightfieldComponent, HeightfieldExample } from './examples/heightfield/heightfield.component';
-import { HingeComponent, HingeExample } from './examples/hinge/hinge.component';
-import { ConstraintsComponent, ConstraintsExample } from './examples/constraints/constraints.component';
-import { RagdollComponent } from './examples/ragdoll/ragdoll.component';
-import { RagdollModelComponent } from './components/ragdoll-model/ragdoll-model.component';
-import { SpringComponent, SpringExample } from './examples/spring/spring.component';
-import { TearComponent, TearExample } from './examples/tear/tear.component';
-import { RigidVehicleComponent } from './examples/rigid_vehicle/rigid_vehicle.component';
-import { RigidBodyModelComponent } from './components/rigidbody-model/rigidbody-model.component';
-import { RaycastVehicleComponent } from './examples/raycast_vehicle/raycast_vehicle.component';
-import { RaycastVehicleModelComponent } from './components/raycast-vehicle-model/raycast-vehicle-model.component';
-import { FloorComponent } from './components/floor.component';
 
 @NgModule({
   declarations: [
@@ -187,14 +280,14 @@ import { FloorComponent } from './components/floor.component';
     NgtMeshStandardMaterialModule,
 
     NgtPhysicsModule,
-    
+
     NgtCannonDebugModule,
 
-    NgtSobaOrbitControlsModule, 
+    NgtSobaOrbitControlsModule,
     NgtSobaTextModule,
-
+    NgtColorAttributeModule,
   ],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/examples/mousepick/mousepick-example.component.html
+++ b/src/app/examples/mousepick/mousepick-example.component.html
@@ -1,17 +1,21 @@
 <!--movement plane-->
-<ngt-mesh #move (ready)="moveready(move.instance.value)" [visible]="false" [rotation]="[0, 90 | radian, 0]">
+<ngt-mesh
+  (ready)="movementPlane = $event"
+  [visible]="false"
+  [rotation]="[0, 90 | radian, 0]"
+>
   <ngt-plane-geometry [args]="[100, 100]"></ngt-plane-geometry>
   <ngt-mesh-standard-material></ngt-mesh-standard-material>
 </ngt-mesh>
 
-  <!--cube that's dragged-->
-  <ngt-mesh #drag (ready)="cubeready(drag.instance.value)" [ref]="boxProps.ref" castShadow>
-    <ngt-box-geometry></ngt-box-geometry>
-    <ngt-mesh-standard-material color='blue'></ngt-mesh-standard-material>
-  </ngt-mesh>
+<!--cube that's dragged-->
+<ngt-mesh [ref]="boxProps.ref" castShadow>
+  <ngt-box-geometry></ngt-box-geometry>
+  <ngt-mesh-standard-material color="blue"></ngt-mesh-standard-material>
+</ngt-mesh>
 
-  <!--marker-->
-  <ngt-mesh [ref]="sphereProps.ref" [visible]="isDragging">
-    <ngt-sphere-geometry [args]="[sphereRadius]"></ngt-sphere-geometry>
-    <ngt-mesh-standard-material color='red'></ngt-mesh-standard-material>
-  </ngt-mesh>
+<!--marker-->
+<ngt-mesh [ref]="sphereProps.ref" [visible]="isDragging">
+  <ngt-sphere-geometry [args]="[sphereRadius]"></ngt-sphere-geometry>
+  <ngt-mesh-standard-material color="red"></ngt-mesh-standard-material>
+</ngt-mesh>

--- a/src/app/examples/mousepick/mousepick.component.html
+++ b/src/app/examples/mousepick/mousepick.component.html
@@ -1,17 +1,22 @@
-<div style="height:100vh">
-  <ngt-canvas (created)="created($event)" [shadows]="true"
-              [camera]="{ position: [16, 4, 0], fov: 65, near:1, far:100 }"
-              [scene]="{ background: 'gray' | color }">
-    <ngt-directional-light [args]="['white' | color, 1.75]"
-                           [position]="[20, 20, 20]" [castShadow]="true">
+<div style="height: 100vh">
+  <ngt-canvas
+    shadows
+    [camera]="{ position: [16, 4, 0], fov: 65, near: 1, far: 100 }"
+  >
+    <ngt-color attach="background" color="gray"></ngt-color>
+
+    <ngt-directional-light
+      color="white"
+      intensity="1.75"
+      castShadow
+      [position]="[20, 20, 20]"
+    >
     </ngt-directional-light>
 
     <ngt-physics>
       <ngt-cannon-debug disabled scale="1.1" color="red">
-
-        <mousepick-example [camera]="camera"></mousepick-example>
+        <mousepick-example></mousepick-example>
         <floor></floor>
-
       </ngt-cannon-debug>
     </ngt-physics>
 

--- a/src/app/examples/mousepick/mousepick.component.ts
+++ b/src/app/examples/mousepick/mousepick.component.ts
@@ -1,8 +1,13 @@
 import { NgtPhysicBody, NgtPhysicConstraint } from '@angular-three/cannon';
 
-import { NgtStore, NgtTriple } from '@angular-three/core';
+import {
+  NgtComponentStore,
+  NgtStore,
+  NgtTriple,
+  tapEffect,
+} from '@angular-three/core';
 import { DOCUMENT } from '@angular/common';
-import { AfterViewInit, Component, Inject, OnDestroy } from '@angular/core';
+import { AfterViewInit, Component, Inject, NgZone } from '@angular/core';
 
 import { Camera, Mesh, Raycaster, Vector2, Vector3 } from 'three';
 
@@ -11,11 +16,12 @@ import { Camera, Mesh, Raycaster, Vector2, Vector3 } from 'three';
   templateUrl: './mousepick-example.component.html',
   providers: [NgtPhysicBody, NgtPhysicConstraint],
 })
-export class MousePickExample implements AfterViewInit, OnDestroy {
+export class MousePickExample
+  extends NgtComponentStore<{ pointerState: 'idle' | 'up' | 'move' }>
+  implements AfterViewInit
+{
   velocity = [0, 0, 0] as NgtTriple;
   sphereRadius = 0.2;
-
-  private cleanup!: () => void;
 
   boxProps = this.physicBody.useBox(() => ({
     mass: 1,
@@ -34,100 +40,129 @@ export class MousePickExample implements AfterViewInit, OnDestroy {
     private physicBody: NgtPhysicBody,
     private physicConstraint: NgtPhysicConstraint,
     private store: NgtStore,
+    private zone: NgZone,
     @Inject(DOCUMENT) private document: Document
-  ) {}
+  ) {
+    super();
+    // initialize pointerState as 'idle'
+    this.set({ pointerState: 'idle' });
+  }
 
   movementPlane!: Mesh;
 
   isDragging = false;
 
-  private velocity_subscription?: () => void;
-
   ngAfterViewInit(): void {
-    const camera = this.store.get((s) => s.camera);
+    // anything physics related, we might want to run outside of Angular zone to prevent Change Detection ticks
+    this.zone.runOutsideAngular(() => {
+      // call the effect
+      this.setupConstraint();
+      // call updateVelocity effect with pointerState as the trigger
+      this.updateVelocity(this.select((s) => s.pointerState));
+    });
+  }
 
-    const constraint = this.physicConstraint.usePointToPointConstraint(
-      this.boxProps.ref,
-      this.sphereProps.ref,
-      {
-        pivotA: [0, 0, 0],
-        pivotB: [0, 0, 0],
-      }
-    );
-    constraint.api.disable();
+  // we create an Effect to setup our constraint.
+  // using tapEffect allows us to clean up this effect on Destroy automatically without having to have cleanup()
+  readonly setupConstraint = this.effect<void>(
+    tapEffect(() => {
+      const camera = this.store.get((s) => s.camera);
 
-    const pointerdown = (event: PointerEvent) => {
-      // Cast a ray from where the mouse is pointing and
-      // see if we hit something
-      const hitPoint = this.getHitPoint(
-        event.clientX,
-        event.clientY,
-        this.boxProps.ref.value as Mesh,
-        camera
+      const constraint = this.physicConstraint.usePointToPointConstraint(
+        this.boxProps.ref,
+        this.sphereProps.ref,
+        {
+          pivotA: [0, 0, 0],
+          pivotB: [0, 0, 0],
+        }
       );
+      constraint.api.disable();
 
-      // if the cube was hit
-      if (hitPoint) {
-        // Move marker mesh on contact point
-        this.moveClickMarker(hitPoint);
-
-        constraint.api.enable();
-
-        // enable constraint between the marker and cube
-        this.isDragging = true;
-      }
-    };
-    this.document.body.addEventListener('pointerdown', pointerdown);
-
-    const pointermove = (event: PointerEvent) => {
-      if (this.isDragging) {
-        // Project the mouse onto the movement plane
+      const pointerdown = (event: PointerEvent) => {
+        // Cast a ray from where the mouse is pointing and
+        // see if we hit something
         const hitPoint = this.getHitPoint(
           event.clientX,
           event.clientY,
-          this.movementPlane,
+          this.boxProps.ref.value as Mesh,
           camera
         );
 
+        // if the cube was hit
         if (hitPoint) {
-          // Move marker mesh on the contact point
+          // Move marker mesh on contact point
           this.moveClickMarker(hitPoint);
 
-          if (!this.velocity_subscription) {
-            // monitor velocity of dragged box until its released
-            this.velocity_subscription = this.boxProps.api.velocity.subscribe(
-              (next) => {
-                this.velocity = next;
-              }
-            );
+          constraint.api.enable();
+
+          // enable constraint between the marker and cube
+          // go back into the zone so this update will trigger render
+          this.zone.run(() => {
+            this.isDragging = true;
+          });
+        }
+      };
+      this.document.body.addEventListener('pointerdown', pointerdown);
+
+      const pointermove = (event: PointerEvent) => {
+        // update pointerState
+        this.set({ pointerState: 'move' });
+
+        if (this.isDragging) {
+          // Project the mouse onto the movement plane
+          const hitPoint = this.getHitPoint(
+            event.clientX,
+            event.clientY,
+            this.movementPlane,
+            camera
+          );
+
+          if (hitPoint) {
+            // Move marker mesh on the contact point
+            this.moveClickMarker(hitPoint);
           }
         }
+      };
+      this.document.body.addEventListener('pointermove', pointermove);
+
+      const pointerup = (event: PointerEvent) => {
+        // update pointerState
+        this.set({ pointerState: 'up' });
+
+        constraint.api.disable();
+
+        // disable constraint between marker and box
+        this.zone.run(() => {
+          this.isDragging = false;
+        });
+      };
+      this.document.body.addEventListener('pointerup', pointerup);
+
+      return () => {
+        this.document.body.removeEventListener('pointerdown', pointerdown);
+        this.document.body.removeEventListener('pointermove', pointermove);
+        this.document.body.removeEventListener('pointerup', pointerup);
+        // reset pointerState on destroy
+        this.set({ pointerState: 'idle' });
+      };
+    })
+  );
+
+  // we setup another effect to update our velocity based on the state of our pointer
+  readonly updateVelocity = this.effect<'idle' | 'move' | 'up'>(
+    tapEffect((pointerState) => {
+      if (pointerState !== 'idle') {
+        const unsubscribe = this.boxProps.api.velocity.subscribe((velocity) => {
+          this.velocity = velocity;
+        });
+
+        return () => {
+          unsubscribe();
+        };
       }
-    };
-    this.document.body.addEventListener('pointermove', pointermove);
-
-    const pointerup = (event: PointerEvent) => {
-      // velocity of other box is now velocity of dragged box
-      this.velocity_subscription?.();
-      this.velocity_subscription = undefined;
-
-      constraint.api.disable();
-
-      // disable constraint between marker and box
-      this.isDragging = false;
-    };
-    this.document.body.addEventListener('pointerup', pointerup);
-
-    this.cleanup = () => {
-      this.document.body.removeEventListener('pointerdown', pointerdown);
-      this.document.body.removeEventListener('pointermove', pointermove);
-      this.document.body.removeEventListener('pointerup', pointerup);
-    };
-  }
-
-  ngOnDestroy(): void {
-    this.cleanup();
-  }
+      return;
+    })
+  );
 
   //
   // Returns an hit point if there's a hit with the mesh, otherwise returns undefined

--- a/src/app/examples/mousepick/mousepick.component.ts
+++ b/src/app/examples/mousepick/mousepick.component.ts
@@ -1,11 +1,10 @@
-import { AfterViewInit, Component, Input, OnDestroy } from "@angular/core";
+import { NgtPhysicBody, NgtPhysicConstraint } from '@angular-three/cannon';
 
-import { Camera, Mesh, Raycaster, Vector2, Vector3 } from "three";
+import { NgtStore, NgtTriple } from '@angular-three/core';
+import { DOCUMENT } from '@angular/common';
+import { AfterViewInit, Component, Inject, OnDestroy } from '@angular/core';
 
-import { NgtState, NgtTriple } from "@angular-three/core";
-
-import { NgtPhysicBody, NgtPhysicConstraintReturn } from "@angular-three/cannon";
-import { NgtPhysicConstraint } from "@angular-three/cannon";
+import { Camera, Mesh, Raycaster, Vector2, Vector3 } from 'three';
 
 @Component({
   selector: 'mousepick-example',
@@ -13,8 +12,6 @@ import { NgtPhysicConstraint } from "@angular-three/cannon";
   providers: [NgtPhysicBody, NgtPhysicConstraint],
 })
 export class MousePickExample implements AfterViewInit, OnDestroy {
-  @Input() camera!: Camera;
-
   velocity = [0, 0, 0] as NgtTriple;
   sphereRadius = 0.2;
 
@@ -30,106 +27,102 @@ export class MousePickExample implements AfterViewInit, OnDestroy {
   sphereProps = this.physicBody.useSphere(() => ({
     mass: 0,
     args: [this.sphereRadius],
-    collisionFilterGroup: 0
+    collisionFilterGroup: 0,
   }));
-
-  get options(): Record<string, any> {
-    return {
-      pivotA: [0, 0, 0],
-      pivotB: [0, 0, 0],
-    }
-  }
 
   constructor(
     private physicBody: NgtPhysicBody,
     private physicConstraint: NgtPhysicConstraint,
-  ) { }
-
-
-  cubeMesh!: Mesh;
-  cubeready(mesh: Mesh) {
-    this.cubeMesh = mesh;
-  }
-
+    private store: NgtStore,
+    @Inject(DOCUMENT) private document: Document
+  ) {}
 
   movementPlane!: Mesh;
-  moveready(mesh: Mesh) {
-    this.movementPlane = mesh;
-  }
 
   isDragging = false;
-  constraint!: NgtPhysicConstraintReturn<'PointToPoint'>;
 
   private velocity_subscription?: () => void;
 
   ngAfterViewInit(): void {
-    this.constraint = this.physicConstraint.usePointToPointConstraint(
+    const camera = this.store.get((s) => s.camera);
+
+    const constraint = this.physicConstraint.usePointToPointConstraint(
       this.boxProps.ref,
       this.sphereProps.ref,
       {
         pivotA: [0, 0, 0],
         pivotB: [0, 0, 0],
-      });
-    this.constraint.api.disable();
+      }
+    );
+    constraint.api.disable();
 
     const pointerdown = (event: PointerEvent) => {
       // Cast a ray from where the mouse is pointing and
       // see if we hit something
-      const hitPoint = this.getHitPoint(event.clientX, event.clientY, this.cubeMesh, this.camera)
+      const hitPoint = this.getHitPoint(
+        event.clientX,
+        event.clientY,
+        this.boxProps.ref.value as Mesh,
+        camera
+      );
 
       // if the cube was hit
       if (hitPoint) {
         // Move marker mesh on contact point
-        this.moveClickMarker(hitPoint)
+        this.moveClickMarker(hitPoint);
 
-        this.constraint.api.enable();
+        constraint.api.enable();
 
         // enable constraint between the marker and cube
-        this.isDragging = true
+        this.isDragging = true;
       }
-    }
-    document.body.addEventListener('pointerdown', pointerdown);
+    };
+    this.document.body.addEventListener('pointerdown', pointerdown);
 
     const pointermove = (event: PointerEvent) => {
       if (this.isDragging) {
         // Project the mouse onto the movement plane
-        const hitPoint = this.getHitPoint(event.clientX, event.clientY, this.movementPlane, this.camera)
+        const hitPoint = this.getHitPoint(
+          event.clientX,
+          event.clientY,
+          this.movementPlane,
+          camera
+        );
 
         if (hitPoint) {
           // Move marker mesh on the contact point
-          this.moveClickMarker(hitPoint)
+          this.moveClickMarker(hitPoint);
 
           if (!this.velocity_subscription) {
             // monitor velocity of dragged box until its released
-            this.velocity_subscription = this.boxProps.api.velocity.subscribe(next => {
-              this.velocity = next;
-            });
+            this.velocity_subscription = this.boxProps.api.velocity.subscribe(
+              (next) => {
+                this.velocity = next;
+              }
+            );
           }
-
         }
       }
-    }
-    document.body.addEventListener('pointermove', pointermove);
-
+    };
+    this.document.body.addEventListener('pointermove', pointermove);
 
     const pointerup = (event: PointerEvent) => {
-
       // velocity of other box is now velocity of dragged box
       this.velocity_subscription?.();
       this.velocity_subscription = undefined;
 
-      this.constraint.api.disable();
+      constraint.api.disable();
 
       // disable constraint between marker and box
-      this.isDragging = false
-    }
-    document.body.addEventListener('pointerup', pointerup);
+      this.isDragging = false;
+    };
+    this.document.body.addEventListener('pointerup', pointerup);
 
     this.cleanup = () => {
-      document.body.removeEventListener('pointerdown', pointerdown);
-      document.body.removeEventListener('pointermove', pointermove);
-      document.body.removeEventListener('pointerup', pointerup);
-    }
+      this.document.body.removeEventListener('pointerdown', pointerdown);
+      this.document.body.removeEventListener('pointermove', pointermove);
+      this.document.body.removeEventListener('pointerup', pointerup);
+    };
   }
 
   ngOnDestroy(): void {
@@ -139,23 +132,27 @@ export class MousePickExample implements AfterViewInit, OnDestroy {
   //
   // Returns an hit point if there's a hit with the mesh, otherwise returns undefined
   //
-  private getHitPoint(clientX: number, clientY: number, mesh: Mesh, camera: Camera): Vector3 | undefined {
+  private getHitPoint(
+    clientX: number,
+    clientY: number,
+    mesh: Mesh,
+    camera: Camera
+  ): Vector3 | undefined {
     // Get 3D point form the client x y
-    const mouse = new Vector2()
-    mouse.x = (clientX / window.innerWidth) * 2 - 1
-    mouse.y = -((clientY / window.innerHeight) * 2 - 1)
+    const mouse = new Vector2();
+    mouse.x = (clientX / window.innerWidth) * 2 - 1;
+    mouse.y = -((clientY / window.innerHeight) * 2 - 1);
 
     const raycaster = new Raycaster();
     // Get the picking ray from the point
-    raycaster.setFromCamera(mouse, camera)
+    raycaster.setFromCamera(mouse, camera);
 
     // Find out if there's a hit
-    const hits = raycaster.intersectObject(mesh)
+    const hits = raycaster.intersectObject(mesh);
 
     // Return the closest hit or undefined
-    return hits.length > 0 ? hits[0].point : undefined
+    return hits.length > 0 ? hits[0].point : undefined;
   }
-
 
   // update marker position
   private moveClickMarker(position: Vector3) {
@@ -166,9 +163,4 @@ export class MousePickExample implements AfterViewInit, OnDestroy {
 @Component({
   templateUrl: './mousepick.component.html',
 })
-export class MousePickComponent {
-  camera!: Camera;
-  created(event: NgtState) {
-    this.camera = event.camera;
-  }
-}
+export class MousePickComponent {}


### PR DESCRIPTION
There are two commits here:
- Clean up and use Camera from `NgtStore`: take a look at this commit if you'd like to see how `this.store.get(s => s.camera)` gives you the camera. You don't have to pass it around from `(created)` event (though that is a valid approach, just a bit more work). Also, I clean up the `(ready)` event on `mousepick` because you don't need them to hold of the underlying `Mesh`. You can just assign straight on the template instead. For `cubeMesh`, you can use `this.boxProps.ref.value` directly (with `as Mesh` because it's a generic `Object3D`, it's no big deal IMO). Last but not least, I minimize the amount of class properties you need (constraint can just be a local variable to `ngAfterViewInit`)

- Use `NgtComponentStore`: in this commit, I attempted to use NgtComponentStore and show how it helps with handling side-effects (like subscribing to the velocity) with automatic clean up.

Sorry for the formatting changes. Please try to ignore those